### PR TITLE
Fix issues when compiling with -preview=in

### DIFF
--- a/source/argparse/internal/arguments.d
+++ b/source/argparse/internal/arguments.d
@@ -304,7 +304,12 @@ package struct Arguments
                 restrictionGroups ~= restriction;
 
                 static if(restriction.required)
-                    restrictions ~= (a,b,c) => Restrictions.RequiredAnyOf(a, b, c, restrictionGroups[index].arguments);
+                {{
+                    // with -preview=in the lambda does not infer correctly
+                    // if appended directly
+                    Restriction restriction = (a, in b, in c) => Restrictions.RequiredAnyOf(a, b, c, restrictionGroups[index].arguments);
+                    restrictions ~= restriction;
+                }}
 
                 enum checkFunc =
                     {
@@ -315,7 +320,10 @@ package struct Arguments
                         }
                     }();
 
-                restrictions ~= (a,b,c) => checkFunc(a, b, c, restrictionGroups[index].arguments);
+                // with -preview=in the lambda does not infer correctly
+                // if appended directly
+                Restriction restriction = (a, in b, in c) => checkFunc(a, b, c, restrictionGroups[index].arguments);
+                restrictions ~= restriction;
 
                 return index;
             }();

--- a/source/argparse/internal/help.d
+++ b/source/argparse/internal/help.d
@@ -471,7 +471,7 @@ unittest
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-private void printUsage(T)(void delegate(string) sink, const ref Style style, in CommandArguments!T cmd)
+private void printUsage(T)(void delegate(string) sink, const ref Style style, in return CommandArguments!T cmd)
 {
     import std.algorithm: map;
     import std.array: join;


### PR DESCRIPTION
Probably there are more cases that make argparse incompatible with preview=in. Since preview=in is supposed to be the default in the future, the implementation should work with it. It would be nice to add multiple unit test configurations that run the tests with these flags, and any other that would make sense to support.

The first fix is found just by running the unit tests with -preview=in. I found the other when playing around with the lib:
```d
struct foo {}
struct T
{
	SumType!(foo) cmd;
}

mixin CLI!T.main((args) {
	return 0;
});
```

Inside `addArgumentImpl` when validating `static if(__traits(compiles, { parseArguments ~= uda.parsingFunc.getParseFunc!RECEIVER; }))` it returns false for watch with preview=in.