### PR TITLE
Turn `main` and `mainComplete` into regular templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,9 +405,9 @@ changes are necessary to generate completer, but you should consider minimizing 
 `argparse_completion` version is defined. For example, you can put all imports into your main function that is passed to
 `CLI!(...).main(alias newMain)` – `newMain` parameter is not used in completer.
 
-If you prefer having separate main module for completer, then you can use `CLI!(...).completeMain` mixin template:
+If you prefer having separate main module for completer, then you can use `CLI!(...).mainComplete` mixin template:
 ```d
-mixin CLI!(...).completeMain;
+mixin CLI!(...).mainComplete;
 ```
 
 In case if you prefer to have your own `main` function and would like to call completer by yourself, you can use

--- a/source/argparse/api/cli.d
+++ b/source/argparse/api/cli.d
@@ -57,7 +57,7 @@ unittest
 
 template CLI(Config config, COMMANDS...)
 {
-    mixin template main(alias newMain)
+    template main(alias newMain)
     {
         import std.sumtype: SumType, match;
 
@@ -184,7 +184,7 @@ template CLI(Config config, COMMAND)
         return 0;
     }
 
-    mixin template mainComplete()
+    template mainComplete()
     {
         int main(string[] argv)
         {
@@ -192,7 +192,7 @@ template CLI(Config config, COMMAND)
         }
     }
 
-    mixin template main(alias newMain)
+    template main(alias newMain)
     {
         version(argparse_completion)
         {


### PR DESCRIPTION
Regular templates are mixable, too, so this doesn’t break anything.