### PR TITLE
Simplify functions with `auto ref` parameters

### DIFF
--- a/source/argparse/api/argument.d
+++ b/source/argparse/api/argument.d
@@ -139,11 +139,6 @@ auto NamedArgument(string[] name...)
     return ArgumentUDA!(ValueParser!(void, void, void, void, void, void))(ArgumentInfo(name.dup)).Optional();
 }
 
-auto NamedArgument(string name)
-{
-    return ArgumentUDA!(ValueParser!(void, void, void, void, void, void))(ArgumentInfo([name])).Optional();
-}
-
 unittest
 {
     auto arg = PositionalArgument(3, "foo");
@@ -179,12 +174,12 @@ unittest
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-auto AllowNoValue(alias valueToUse, T)(auto ref ArgumentUDA!T uda)
+auto AllowNoValue(alias valueToUse, T)(ArgumentUDA!T uda)
 {
     return uda.ActionNoValue!(() => valueToUse);
 }
 
-auto RequireNoValue(alias valueToUse, T)(auto ref ArgumentUDA!T uda)
+auto RequireNoValue(alias valueToUse, T)(ArgumentUDA!T uda)
 {
     auto desc = uda.AllowNoValue!valueToUse;
     desc.info.minValuesCount = 0;
@@ -212,12 +207,12 @@ unittest
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Parsing customization
 
-auto PreValidation(alias func, T)(auto ref ArgumentUDA!T uda)
+auto PreValidation(alias func, T)(ArgumentUDA!T uda)
 {
     return ArgumentUDA!(uda.parsingFunc.changePreValidation!func)(uda.tupleof);
 }
 
-auto Parse(alias func, T)(auto ref ArgumentUDA!T uda)
+auto Parse(alias func, T)(ArgumentUDA!T uda)
 {
     auto desc = ArgumentUDA!(uda.parsingFunc.changeParse!func)(uda.tupleof);
 
@@ -232,17 +227,17 @@ auto Parse(alias func, T)(auto ref ArgumentUDA!T uda)
     return desc;
 }
 
-auto Validation(alias func, T)(auto ref ArgumentUDA!T uda)
+auto Validation(alias func, T)(ArgumentUDA!T uda)
 {
     return ArgumentUDA!(uda.parsingFunc.changeValidation!func)(uda.tupleof);
 }
 
-auto Action(alias func, T)(auto ref ArgumentUDA!T uda)
+auto Action(alias func, T)(ArgumentUDA!T uda)
 {
     return ArgumentUDA!(uda.parsingFunc.changeAction!func)(uda.tupleof);
 }
 
-auto ActionNoValue(alias func, T)(auto ref ArgumentUDA!T uda)
+auto ActionNoValue(alias func, T)(ArgumentUDA!T uda)
 {
     auto desc = ArgumentUDA!(uda.parsingFunc.changeNoValueAction!func)(uda.tupleof);
     desc.info.minValuesCount = 0;
@@ -333,9 +328,9 @@ private struct CounterParsingFunction
     }
 }
 
-auto Counter(T)(auto ref ArgumentUDA!T uda)
+auto Counter(T)(ArgumentUDA!T uda)
 {
-    auto desc = ArgumentUDA!(CounterParsingFunction)(uda.tupleof);
+    auto desc = ArgumentUDA!CounterParsingFunction(uda.tupleof);
     desc.info.minValuesCount = 0;
     desc.info.maxValuesCount = 0;
     return desc;

--- a/source/argparse/api/argumentgroup.d
+++ b/source/argparse/api/argumentgroup.d
@@ -14,13 +14,13 @@ auto ArgumentGroup(string name)
     return Group(name);
 }
 
-auto ref Description(T : Group)(auto ref T group, string text)
+auto ref Description()(auto ref Group group, string text)
 {
     group.description = text;
     return group;
 }
 
-auto ref Description(T : Group)(auto ref T group, string delegate() text)
+auto ref Description()(auto ref Group group, string delegate() text)
 {
     group.description = text;
     return group;

--- a/source/argparse/api/command.d
+++ b/source/argparse/api/command.d
@@ -18,49 +18,49 @@ unittest
 }
 
 
-auto ref Usage(T : CommandInfo)(auto ref T cmd, string text)
+auto ref Usage()(auto ref CommandInfo cmd, string text)
 {
     cmd.usage = text;
     return cmd;
 }
 
-auto ref Usage(T : CommandInfo)(auto ref T cmd, string delegate() text)
+auto ref Usage()(auto ref CommandInfo cmd, string delegate() text)
 {
     cmd.usage = text;
     return cmd;
 }
 
-auto ref Description(T : CommandInfo)(auto ref T cmd, string text)
+auto ref Description()(auto ref CommandInfo cmd, string text)
 {
     cmd.description = text;
     return cmd;
 }
 
-auto ref Description(T : CommandInfo)(auto ref T cmd, string delegate() text)
+auto ref Description()(auto ref CommandInfo cmd, string delegate() text)
 {
     cmd.description = text;
     return cmd;
 }
 
-auto ref ShortDescription(T : CommandInfo)(auto ref T cmd, string text)
+auto ref ShortDescription()(auto ref CommandInfo cmd, string text)
 {
     cmd.shortDescription = text;
     return cmd;
 }
 
-auto ref ShortDescription(T : CommandInfo)(auto ref T cmd, string delegate() text)
+auto ref ShortDescription()(auto ref CommandInfo cmd, string delegate() text)
 {
     cmd.shortDescription = text;
     return cmd;
 }
 
-auto ref Epilog(T : CommandInfo)(auto ref T cmd, string text)
+auto ref Epilog()(auto ref CommandInfo cmd, string text)
 {
     cmd.epilog = text;
     return cmd;
 }
 
-auto ref Epilog(T : CommandInfo)(auto ref T cmd, string delegate() text)
+auto ref Epilog()(auto ref CommandInfo cmd, string delegate() text)
 {
     cmd.epilog = text;
     return cmd;

--- a/source/argparse/api/restriction.d
+++ b/source/argparse/api/restriction.d
@@ -11,7 +11,7 @@ import std.conv: to;
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Required group
 
-auto ref Required(T : RestrictionGroup)(auto ref T group)
+auto ref Required()(auto ref RestrictionGroup group)
 {
     group.required = true;
     return group;


### PR DESCRIPTION
1. The overload `NamedArgument(string)` is redundant since there is `NamedArgument(string[]...)`.
2. `auto ref` is unnecessary when the argument is not mutated.
3. The type of an `auto ref` parameter doesn’t need to be a template placeholder; it can be a concrete type. However, a function featuring such parameter should be a template nonetheless.