### PR TITLE
Prettify `tools/deps.sh`

### DIFF
--- a/tools/deps.sh
+++ b/tools/deps.sh
@@ -1,5 +1,19 @@
-cat <<EOF | dot -Tpng > deps.png
-digraph {
-$(egrep -rw 'import +argparse' --include=*.d source | sed 's/public \+//; s/^source\/\(.\+\)\.d: *import \([^:; ]\+\).*/"\2" -> "\1"/; s/\//./g; s/\.package//g')
-}
-EOF
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\t\n'
+[[ $# -le 1 ]] || exit 2
+
+{
+    cd -- "${0%[/\\]*}/../source"
+
+    echo 'digraph {'
+
+    grep -rw 'import \+argparse' --include='*.d' | sed -E '
+    s/^(.+)\.d: *(public +)?import +([^:; ]+).*/"\3" -> "\1"/
+    s|/|.|g
+    s/\.package//g
+    ' | sort -u
+
+    echo '}'
+} | dot -Tsvg -o "${1-deps.svg}"


### PR DESCRIPTION
1. Executable bit is set.
2. Runnable from any directory now.
3. Output-file name is customizable.
4. Produces SVG rather than PNG (15 times smaller).
5. Duplicate edges (due to multiple imports) are discarded.
6. `egrep` is deprecated; we are advised to use `grep -E`, but it is simpler to just put a backslash here. `sed -E`, on the other hand, cleans up the code significantly.