### PR TITLE
Fix compatibility with D 2.099

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        dc: [dmd-latest, ldc-latest]
+        dc: [dmd-2.099.1, dmd-latest, ldc-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/source/argparse/ansi.d
+++ b/source/argparse/ansi.d
@@ -49,7 +49,7 @@ package struct TextStyle
 {
     private string style = prefix;
 
-    private this(const(ubyte)[] st...) scope inout nothrow pure @safe
+    private this(scope const(ubyte)[] st...) scope inout nothrow pure @safe
     {
         import std.algorithm.iteration: joiner, map;
         import std.array: appender;
@@ -256,7 +256,7 @@ private inout(char)[][2] findNextTextChunk(return scope inout(char)[] text) noth
     }
 }
 
-public auto getUnstyledText(C : char)(C[] text)
+public auto getUnstyledText(C : char)(return scope C[] text)
 {
     struct Unstyler
     {

--- a/source/argparse/internal/argumentudahelpers.d
+++ b/source/argparse/internal/argumentudahelpers.d
@@ -68,13 +68,16 @@ private template defaultValuesCount(T)
 package auto getMemberArgumentUDA(TYPE, string symbol)(const Config config)
 {
     import argparse.internal.arguments: finalize;
-    import std.meta: Filter;
+    import std.meta: AliasSeq, Filter;
 
     alias member = __traits(getMember, TYPE, symbol);
     alias MemberType = typeof(member);
 
-    alias udas     = Filter!(isArgumentUDA, __traits(getAttributes, member));
-    alias typeUDAs = Filter!(isArgumentUDA, __traits(getAttributes, MemberType));
+    alias udas = Filter!(isArgumentUDA, __traits(getAttributes, member));
+    static if(__traits(compiles, __traits(getAttributes, MemberType)))
+        alias typeUDAs = Filter!(isArgumentUDA, __traits(getAttributes, MemberType));
+    else // On D <2.101, we are not allowed to query attributes of built-in types
+        alias typeUDAs = AliasSeq!();
 
     static assert(udas.length <= 1, "Member "~TYPE.stringof~"."~symbol~" has multiple '*Argument' UDAs");
     static assert(typeUDAs.length <= 1, "Type "~MemberType.stringof~" has multiple '*Argument' UDAs");

--- a/source/argparse/internal/parser.d
+++ b/source/argparse/internal/parser.d
@@ -333,7 +333,7 @@ private Entry getNextEntry(bool bundling)(Config config, ref string[] args,
 
 unittest
 {
-    auto test(string[] args) => getNextEntry!false(Config.init, args, null, null, null);
+    auto test(string[] args) { return getNextEntry!false(Config.init, args, null, null, null); }
 
     assert(test([""]) == Entry(Unknown("")));
     assert(test(["--","a","-b","c"]) == Entry(EndOfArgs(["a","-b","c"])));
@@ -341,7 +341,7 @@ unittest
 
 unittest
 {
-    auto test(string[] args) => getNextEntry!false(Config.init, args, null, null, null);
+    auto test(string[] args) { return getNextEntry!false(Config.init, args, null, null, null); }
 
     assert(test([""]) == Entry(Unknown("")));
     assert(test(["--","a","-b","c"]) == Entry(EndOfArgs(["a","-b","c"])));

--- a/source/argparse/internal/restriction.d
+++ b/source/argparse/internal/restriction.d
@@ -24,7 +24,7 @@ unittest
 {
     auto f = RequiredArg(Config.init, ArgumentInfo([],[],[""]), 0);
 
-    assert(f(bool[size_t].init).isError("argument is required"));
+    assert(f((bool[size_t]).init).isError("argument is required"));
 
     assert(f([1:true]).isError("argument is required"));
 
@@ -64,7 +64,7 @@ unittest
 {
     auto f = RequiredTogether(Config.init, [ArgumentInfo([],[],["--a"]), ArgumentInfo([],[],["--b"]), ArgumentInfo([],[],["--c"])]);
 
-    assert(f(bool[size_t].init, [0,1]));
+    assert(f((bool[size_t]).init, [0,1]));
 
     assert(f([0:true], [0,1]).isError("Missed argument","--a"));
     assert(f([1:true], [0,1]).isError("Missed argument","--b"));
@@ -95,7 +95,7 @@ unittest
 {
     auto f = RequiredAnyOf(Config.init, [ArgumentInfo([],[],["--a"]), ArgumentInfo([],[],["--b"]), ArgumentInfo([],[],["--c"])]);
 
-    assert(f(bool[size_t].init, [0,1]).isError("One of the following arguments is required","--a","--b"));
+    assert(f((bool[size_t]).init, [0,1]).isError("One of the following arguments is required","--a","--b"));
     assert(f([2:true], [0,1]).isError("One of the following arguments is required","--a","--b"));
 
     assert(f([0:true], [0,1]));
@@ -131,7 +131,7 @@ unittest
 {
     auto f = MutuallyExclusive(Config.init, [ArgumentInfo([],[],["--a"]), ArgumentInfo([],[],["--b"]), ArgumentInfo([],[],["--c"])]);
 
-    assert(f(bool[size_t].init, [0,1]));
+    assert(f((bool[size_t]).init, [0,1]));
 
     assert(f([0:true], [0,1]));
     assert(f([1:true], [0,1]));


### PR DESCRIPTION
Closes #144.

I’m planning to reduce the minimal required version of the D frontend down to 2.095. Why this version? Because I tried 2.094, and the compiler failed to infer that (generated) `opEquals` of a struct containing a `SumType` was `const`. That seemed too suspicious to me; I’m afraid it can backfire in any unexpected way. I could have understood something wrong though; worth checking once again.

Should I continue working on lowering the requirements in this PR, or would you prefer to merge it in its current state?