### PR TITLE
Convert Config.errorHandler from delegate to function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1624,8 +1624,8 @@ See [ANSI coloring and styling](#ansi-colors-and-styles) for details.
 
 ### Error handling
 
-`Config.errorHandler` – this is a handler function for all errors occurred during parsing the command line. It might be
-either a function or a delegate that takes `string` parameter which would be an error message.
+`Config.errorHandler` – this is a handler function for all errors occurred during parsing the command line.
+It a function that receives `string` parameter which would be an error message.
 
 The default behavior is to print error message to `stderr`.
 

--- a/source/argparse/api/cli.d
+++ b/source/argparse/api/cli.d
@@ -22,8 +22,8 @@ private void onError(Config config, alias printer = defaultErrorPrinter)(string 
 {
     import std.algorithm.iteration: joiner;
 
-    static if(config.errorHandlerFunc)
-        config.errorHandlerFunc(message);
+    if(config.errorHandler)
+        config.errorHandler(message);
     else
         try
         {
@@ -190,3 +190,16 @@ template CLI(Config config, COMMAND)
 }
 
 alias CLI(COMMANDS...) = CLI!(Config.init, COMMANDS);
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+unittest
+{
+    struct Args {}
+
+    mixin CLI!({
+        Config cfg;
+        cfg.errorHandler = (string s) {};
+        return cfg;
+    }(), Args).main!((_){});
+}

--- a/source/argparse/api/cli.d
+++ b/source/argparse/api/cli.d
@@ -50,6 +50,16 @@ unittest
     assert(collectExceptionMsg!Error(onError!(Config.init, printer)("text")) == "My Message.");
 }
 
+unittest
+{
+    enum config = {
+        Config config;
+        config.errorHandler = (string s) { assert(s == "error text"); };
+        return config;
+    }();
+
+    onError!config("error text");
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Public API for CLI wrapper

--- a/source/argparse/config.d
+++ b/source/argparse/config.d
@@ -74,38 +74,17 @@ struct Config
 
 
     /**
-       Delegate that processes error messages if they happen during argument parsing.
+       Function that processes error messages if they happen during argument parsing.
        By default all errors are printed to stderr.
      */
-    package void delegate(string s) nothrow errorHandlerFunc;
-
-    @property auto errorHandler(void function(string s) nothrow func)
-    {
-        return errorHandlerFunc = (string msg) { func(msg); };
-    }
-
-    @property auto errorHandler(void delegate(string s) nothrow func)
-    {
-        return errorHandlerFunc = func;
-    }
+    void function(string s) nothrow errorHandler;
 }
 
 unittest
 {
-    auto f = function(string s) nothrow {};
-
-    Config c;
-    assert(!c.errorHandlerFunc);
-    assert((c.errorHandler = f));
-    assert(c.errorHandlerFunc);
-}
-
-unittest
-{
-    auto f = delegate(string s) nothrow {};
-
-    Config c;
-    assert(!c.errorHandlerFunc);
-    assert((c.errorHandler = f) == f);
-    assert(c.errorHandlerFunc == f);
+    enum c = {
+        Config cfg;
+        cfg.errorHandler = (string s) { };
+        return cfg;
+    }();
 }


### PR DESCRIPTION
Closes #118 

I think having `errorHandler` as delegate was over-engineering that didn't even work correctly.