### PR TITLE
Fix argument bundling

### DIFF
--- a/source/argparse/package.d
+++ b/source/argparse/package.d
@@ -329,6 +329,11 @@ unittest
     assert(CLI!(config, T).parseArgs!((T t) { assert(t == T(true, true)); return 12345; })(["-a","-b"]) == 12345);
     assert(CLI!(config, T).parseArgs!((T t) { assert(t == T(true, true)); return 12345; })(["-ab"]) == 12345);
     assert(CLI!(config, T).parseArgs!((T t) { assert(t == T(true, true, "foo")); return 12345; })(["-abc=foo"]) == 12345);
+    assert(CLI!(config, T).parseArgs!((T t) { assert(t == T(true, true, "foo")); return 12345; })(["-a","-bc=foo"]) == 12345);
+    assert(CLI!(config, T).parseArgs!((T t) { assert(t == T(true, true, "foo")); return 12345; })(["-a","-bcfoo"]) == 12345);
+    assert(CLI!(config, T).parseArgs!((T t) { assert(t == T(true, true, "foo")); return 12345; })(["-a","-b","-cfoo"]) == 12345);
+    assert(CLI!(config, T).parseArgs!((T t) { assert(t == T(true, true, "foo")); return 12345; })(["-a","-b","-c=foo"]) == 12345);
+    assert(CLI!(config, T).parseArgs!((T t) { assert(t == T(true, true, "foo")); return 12345; })(["-a","-b","-c","foo"]) == 12345);
 }
 
 unittest


### PR DESCRIPTION
Tested with example from #112:

Case-sensitive:
```
./prog -b -s=abc   =>   true <abc>
./prog -b -s abc   =>   true <abc>
./prog -b -sabc   =>   true <abc>
./prog -bsabc   =>   true <abc>
./prog -bs=abc   =>   true <abc>
./prog -b -S=abc   =>   Error: Unrecognized arguments: ["-S=abc"]
./prog -b -S abc   =>   Error: Unrecognized arguments: ["-S", "abc"]
./prog -b -Sabc   =>   Error: Unrecognized arguments: ["-Sabc"]
./prog -bSabc   =>   Error: Unrecognized arguments: ["-Sabc"]
./prog -bS=abc   =>   Error: Unrecognized arguments: ["-S=abc"]
./prog -B -s=abc   =>   Error: Unrecognized arguments: ["-B"]
./prog -B -s abc   =>   Error: Unrecognized arguments: ["-B"]
./prog -B -sabc   =>   Error: Unrecognized arguments: ["-B"]
./prog -Bsabc   =>   Error: Unrecognized arguments: ["-Bsabc"]
./prog -Bs=abc   =>   Error: Unrecognized arguments: ["-Bs=abc"]
./prog -B -S=abc   =>   Error: Unrecognized arguments: ["-B", "-S=abc"]
./prog -B -S abc   =>   Error: Unrecognized arguments: ["-B", "-S", "abc"]
./prog -B -Sabc   =>   Error: Unrecognized arguments: ["-B", "-Sabc"]
./prog -BSabc   =>   Error: Unrecognized arguments: ["-BSabc"]
./prog -BS=abc   =>   Error: Unrecognized arguments: ["-BS=abc"]
```

Case-insensitive:
```
./prog -b -s=abc   =>   true <abc>
./prog -b -s abc   =>   true <abc>
./prog -b -sabc   =>   true <abc>
./prog -bsabc   =>   true <abc>
./prog -bs=abc   =>   true <abc>
./prog -b -S=abc   =>   true <abc>
./prog -b -S abc   =>   true <abc>
./prog -b -Sabc   =>   true <abc>
./prog -bSabc   =>   true <abc>
./prog -bS=abc   =>   true <abc>
./prog -B -s=abc   =>   true <abc>
./prog -B -s abc   =>   true <abc>
./prog -B -sabc   =>   true <abc>
./prog -Bsabc   =>   true <abc>
./prog -Bs=abc   =>   true <abc>
./prog -B -S=abc   =>   true <abc>
./prog -B -S abc   =>   true <abc>
./prog -B -Sabc   =>   true <abc>
./prog -BSabc   =>   true <abc>
./prog -BS=abc   =>   true <abc>
```

Closes #112 