### PR TITLE
Fix linker error related to `-preview=in`

### DIFF
--- a/source/argparse/internal/help.d
+++ b/source/argparse/internal/help.d
@@ -327,7 +327,7 @@ unittest
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-private string printValue(in ArgumentInfo info)
+private string printValue(ref scope const ArgumentInfo info)
 {
     if(info.maxValuesCount.get == 0)
         return "";


### PR DESCRIPTION
To reproduce it, you need a separate DUB package. Minimal example:

```d
#!/usr/bin/env dub
/+ dub.sdl:
dependency "argparse" path="."
dflags /*"-dip1000"*/ "-preview=in"
+/
import argparse;

struct Args { }

mixin CLI!Args.main!((args) { });
```

With such configuration this file gets compiled with `-preview=in` but `argparse` does not. This leads to different name mangling of one function – and consequently to errors during linking.