### PR TITLE
fix(api/ansi): Make the unittest order-independent

### DIFF
--- a/source/argparse/api/ansi.d
+++ b/source/argparse/api/ansi.d
@@ -48,7 +48,7 @@ private struct AnsiStylingArgument
 unittest
 {
     AnsiStylingArgument arg;
-    assert(!arg);
+    arg.isEnabled = false;
     AnsiStylingArgument.actionNoValue(arg, Param!void.init);
     assert(arg);
 
@@ -58,6 +58,7 @@ unittest
 unittest
 {
     AnsiStylingArgument arg;
+    arg.isEnabled = false;
 
     AnsiStylingArgument.action(arg, Param!string(null, "", "always"));
     assert(arg);
@@ -70,6 +71,7 @@ unittest
 {
     Config config;
     AnsiStylingArgument arg;
+    arg.isEnabled = false;
 
     config.stylingMode = Config.StylingMode.on;
     AnsiStylingArgument.action(arg, Param!string(&config, "", "auto"));


### PR DESCRIPTION
Running 'dub test' on my machine with DUB v1.39 and LDC v1.40.1 fails on the assert at line 48, and it's easy to see why: because this tests static data, if the tests run in a different order than top-to-bottom (or if another module changes the value of the static boolean), then this will not pass. To make it more robust, we make sure to reset it at the beginning of every test.

A better long term solution would be to make the struct not have static members, and expose a static instance of it. However, due to the current API exposed, this change is not currently possible.