### PR TITLE
If argument value is empty string, it should be non-null

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@
 * Added support for environment fallback, so adding `EnvFallback("VAR")` to an argument would automatically populate the argument with the content
   of the `VAR` environment variable if nothing is provided on the command line.
 
+* Fix for empty argument values: they are now non-null empty strings (`""` instead of `string.init` before).
+
 ### Other changes
 
 * Removed dependency on `std.regex`.

--- a/source/argparse/internal/parsefunc.d
+++ b/source/argparse/internal/parsefunc.d
@@ -110,7 +110,10 @@ package enum Convert(TYPE) = ParseFunc!TYPE
             import std.conv: to;
 
             foreach (value; param.value)
-                receiver = value.length > 0 ? value.to!TYPE : TYPE.init;
+                static if(is(TYPE == typeof(value)))
+                    receiver = value;
+                else
+                    receiver = value.length > 0 ? value.to!TYPE : TYPE.init;
 
             return Result.Success;
         }
@@ -132,6 +135,8 @@ unittest
     assert(test!int("7") == 7);
     assert(test!string("7") == "7");
     assert(test!char("7") == '7');
+    assert(test!string("") == "");
+    assert(test!string("") !is null);
 }
 
 unittest


### PR DESCRIPTION
Fixes #219 