### PR TITLE
fix: Test with DMD v2.108

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,9 +13,10 @@ jobs:
   matrix-build:
     name: Matrix Build
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        dc: [dmd-2.111.0, ldc-latest]
+        dc: [dmd-2.108.1, dmd-2.111.0, ldc-latest]
         #dc: [dmd-latest, ldc-latest]
         include:
           - { os: macOS-latest, dc: ldc-latest }

--- a/source/argparse/helpprinter.d
+++ b/source/argparse/helpprinter.d
@@ -244,17 +244,17 @@ public class HelpPrinter
 
     HelpScreen createHelpScreen(CommandHelpInfo[] commands)
     {
-        auto ref currentCmd = commands[$-1];
+        CommandHelpInfo* currentCmd = &commands[$-1];
 
         auto cmdFullName = commands.map!((ref _) => _.name).array;
 
-        auto helpScreen = HelpScreen(formatCommandUsage(cmdFullName, currentCmd),
-                                     currentCmd.description,
-                                     currentCmd.epilog);
+        auto helpScreen = HelpScreen(formatCommandUsage(cmdFullName, *currentCmd),
+                                     (*currentCmd).description,
+                                     (*currentCmd).epilog);
 
         // sub commands go first
-        if(currentCmd.subCommands.length > 0)
-            helpScreen.groups ~= createSubCommandGroup(currentCmd);
+        if((*currentCmd).subCommands.length > 0)
+            helpScreen.groups ~= createSubCommandGroup(*currentCmd);
 
         // then arguments
         helpScreen.groups ~= createArgumentsGroups(commands);


### PR DESCRIPTION
This extends the compatibility beyond DMD 2.111.0, by avoiding the use of 'ref' local variables.
The oldest supported version is v2.108 as named arguments are heavily used within argparse.