### PR TITLE
Print usage in case of error

### DIFF
--- a/docs/code_snippets/config_helpOnError.d
+++ b/docs/code_snippets/config_helpOnError.d
@@ -1,0 +1,23 @@
+import argparse;
+
+struct T
+{
+    @(NamedArgument.Required)
+    string a;
+}
+
+// Only the error message is printed (default)
+T t1;
+assert(CLI!T.parseArgs(t1, []).isError);
+
+// Usage line is printed to stderr in front of the error message
+enum Config cfgUsage = { helpOnError: Config.HelpOnError.usage };
+
+T t2;
+assert(CLI!(cfgUsage, T).parseArgs(t2, []).isError);
+
+// The whole help screen is printed instead
+enum Config cfgFull = { helpOnError: Config.HelpOnError.full };
+
+T t3;
+assert(CLI!(cfgFull, T).parseArgs(t3, []).isError);

--- a/docs/topics/reference/Config.md
+++ b/docs/topics/reference/Config.md
@@ -126,6 +126,36 @@ Help text from the first part of the example code above:
 <img src="config_help.png" alt="Config help example" border-effect="rounded"/>
 
 
+## Help on error {id="helpOnError"}
+
+`Config.helpOnError` controls what is printed to `stderr` in front of the error message when command line parsing
+failed. It has the following type: `enum HelpOnError { none, usage, full }`:
+- `Config.HelpOnError.none`: **nothing** is printed, only the error message itself.
+- `Config.HelpOnError.usage`: the **usage line** is printed:
+
+  ```
+  Usage: prog sub [--req REQ] [-h]
+  Error: The following argument is required: '--req'
+  ```
+
+- `Config.HelpOnError.full`: the **whole help screen** is printed, the same one that `-h`/`--help` prints.
+
+Whatever is printed belongs to the command that was being parsed when the error happened, so an error in a
+[subcommand](Subcommands.md) refers to that subcommand rather than to the top level command.
+
+[`Config.helpPrinter`](#helpPrinter) is used for `Config.HelpOnError.full` only, since that is the setting that
+customizes the help screen. There is no such hook for the usage line.
+
+Note that this setting is independent from [`Config.errorHandler`](#errorHandler): the latter receives the error
+message only, so providing a custom error handler does not suppress the usage line or the help screen.
+
+Default is `Config.HelpOnError.none`.
+
+Example:
+
+<code-block src="code_snippets/config_helpOnError.d" lang="c++"/>
+
+
 ## Styling mode {id="stylingMode"}
 
 `Config.stylingMode` controls whether styling for help text and errors should be enabled.

--- a/source/argparse/api/cli.d
+++ b/source/argparse/api/cli.d
@@ -1,7 +1,10 @@
 module argparse.api.cli;
 
 import argparse.config;
+import argparse.helpinfo: CommandHelpInfo;
+import argparse.helpprinter: HelpPrinter;
 import argparse.result;
+import argparse.style: Style;
 import argparse.api.ansi: ansiStylingArgument;
 import argparse.ansi: getUnstyledText;
 import argparse.internal.parser: parseArgs;
@@ -18,7 +21,7 @@ private void defaultErrorPrinter(T...)(T message)
     stderr.writeln(message);
 }
 
-private void onError(Config config, alias printer = defaultErrorPrinter)(string message) nothrow
+private void onError(alias printer = defaultErrorPrinter)(Config config, string message) nothrow
 {
     import std.algorithm.iteration: joiner;
 
@@ -47,14 +50,145 @@ unittest
         throw new Exception("My Message.");
     }
 
-    assert(collectExceptionMsg!Error(onError!(Config.init, printer)("text")) == "My Message.");
+    assert(collectExceptionMsg!Error(onError!printer(Config.init, "text")) == "My Message.");
 }
 
 unittest
 {
     enum Config config = { errorHandler: s => assert(s == "error text") };
 
-    onError!config("error text");
+    onError(config, "error text");
+}
+
+// Prints what accompanies an error message, as selected by Config.helpOnError.
+//
+// Config.helpPrinter is consulted for `full` only: that hook renders the help screen, which is what `full`
+// prints, whereas `usage` prints the short "Usage: ..." line that conventionally precedes an error and has no
+// corresponding hook.
+private void onErrorHelp(alias printer = defaultErrorPrinter)(Config config, CommandHelpInfo[] cmds) nothrow
+{
+    import std.algorithm.iteration: map;
+    import std.array: array;
+
+    // Bail out before creating the style and the help printer: nothing below is needed to print nothing
+    if(config.helpOnError == Config.HelpOnError.none || cmds.length == 0)
+        return;
+
+    try
+    {
+        auto style = ansiStylingArgument.stderrStyling ? config.styling : Style.None;
+
+        scope hp = new HelpPrinter(config, style);
+
+        final switch(config.helpOnError)
+        {
+            case Config.HelpOnError.none:
+                assert(false);  // returned above
+
+            case Config.HelpOnError.usage:
+                // The usage line is built for the command that was being parsed (the last one in the stack)
+                // and it is prefixed with the names of all the commands that lead to it.
+                printer(hp.formatCommandUsage(cmds.map!((ref _) => _.name).array, cmds[$-1]));
+                break;
+
+            case Config.HelpOnError.full:
+                if(config.helpPrinter)
+                    config.helpPrinter(config, style, cmds);
+                else
+                {
+                    import std.stdio: stderr;
+
+                    scope auto output = stderr.lockingTextWriter();
+
+                    hp.printHelp(_ => output.put(_), cmds);
+                }
+                break;
+        }
+    }
+    catch(Exception e)
+    {
+        throw new Error(e.msg);
+    }
+}
+
+unittest
+{
+    static string printed;
+    static void printer(T...)(T m)
+    {
+        import std.conv: text;
+
+        printed = text(m);
+    }
+
+    auto cmds = [CommandHelpInfo(name: "prog"), CommandHelpInfo(name: "sub")];
+
+    static assert(Config.init.helpOnError == Config.HelpOnError.none);   // default
+
+    {
+        enum Config config = {
+            helpOnError: Config.HelpOnError.usage,
+            stylingMode: Config.StylingMode.off,
+        };
+
+        // No help info attached => nothing is printed
+        printed = null;
+        onErrorHelp!printer(config, []);
+        assert(printed is null);
+
+        // Usage line of the whole command stack
+        printed = null;
+        onErrorHelp!printer(config, cmds);
+        assert(printed == "Usage: prog sub");
+    }
+    {
+        enum Config config = { helpOnError: Config.HelpOnError.none };
+
+        printed = null;
+        onErrorHelp!printer(config, cmds);
+        assert(printed is null);
+    }
+    {
+        // `full` renders the help screen, so it goes through Config.helpPrinter when one is provided
+        enum Config config = {
+            helpOnError: Config.HelpOnError.full,
+            helpPrinter: (cfg, style, c) { assert(c.length == 2 && c[$-1].name == "sub"); },
+        };
+
+        printed = null;
+        onErrorHelp!printer(config, cmds);
+        assert(printed is null);   // the printer is not used by `full`
+    }
+    {
+        // ... and it renders the help screen to stderr when no Config.helpPrinter is provided
+        enum Config config = {
+            helpOnError: Config.HelpOnError.full,
+            stylingMode: Config.StylingMode.off,
+        };
+
+        printed = null;
+        onErrorHelp!printer(config, cmds);
+        assert(printed is null);   // the printer is not used by `full`
+    }
+}
+
+unittest
+{
+    import std.exception;
+
+    static void printer(T...)(T m)
+    {
+        throw new Exception("My Message.");
+    }
+
+    enum Config config = {
+        helpOnError: Config.HelpOnError.usage,
+        stylingMode: Config.StylingMode.off,
+    };
+
+    auto cmds = [CommandHelpInfo(name: "prog")];
+
+    assert(collectExceptionMsg!Error(onErrorHelp!printer(config, cmds)) == "My Message.");
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -91,7 +225,12 @@ template CLI(Config config, COMMAND)
         auto res = .parseArgs!config(receiver, args, unrecognizedArgs);
 
         if(res.isError)
-            onError!config(res.errorMessage);
+        {
+            static if(config.helpOnError != Config.HelpOnError.none)
+                onErrorHelp(config, res.cmdHelpInfo);
+
+            onError(config, res.errorMessage);
+        }
 
         return res;
     }
@@ -112,8 +251,17 @@ template CLI(Config config, COMMAND)
         auto res = parseKnownArgs(receiver, args);
         if(res && args.length > 0)
         {
+            // Parsing itself succeeded, so the help info is carried by the successful result: move it onto
+            // the error that replaces it, otherwise the command that was being parsed would be lost here.
+            auto cmdHelpInfo = res.cmdHelpInfo;
+
             res = Result.Error(config.errorExitCode, "Unrecognized arguments: ", args);
-            onError!config(res.errorMessage);
+            res.cmdHelpInfo = cmdHelpInfo;
+
+            static if(config.helpOnError != Config.HelpOnError.none)
+                onErrorHelp(config, res.cmdHelpInfo);
+
+            onError(config, res.errorMessage);
         }
 
         return res;
@@ -516,4 +664,104 @@ unittest
 
     assert(test_main(["executable","-h"]) == 0);// argv[0] is executable
     assert(test_main(["executable","--help"]) == 0);// argv[0] is executable
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Config.helpOnError
+
+version(unittest)
+{
+    // Names of the commands that whatever is printed on error is built from, i.e. what `onErrorHelp` receives
+    private string[] helpOnErrorCommandNames(Result res)
+    {
+        import std.algorithm.iteration: map;
+        import std.array: array;
+
+        return res.cmdHelpInfo.map!((ref _) => _.name).array;
+    }
+}
+
+unittest
+{
+    import argparse.api.argument;
+
+    struct T
+    {
+        @(NamedArgument.Required) string s;
+    }
+
+    // `usage` and `full` both need the help info, `none` doesn't
+    static foreach(mode; [Config.HelpOnError.usage, Config.HelpOnError.full])
+    {{
+        enum Config config = {
+            helpOnError: mode,
+            stylingMode: Config.StylingMode.off,
+            helpPrinter: (cfg, style, cmds) { },
+            errorHandler: (msg) { },
+        };
+
+        T t;
+
+        auto res = CLI!(config, T).parseArgs(t, []);
+        assert(res.isError("The following argument is required"));
+        assert(res.helpOnErrorCommandNames.length == 1);
+
+        // Nothing is printed when parsing succeeds, but the help info is still carried by the result so that
+        // errors detected afterwards (unrecognized arguments) can be reported against the right command
+        assert(CLI!(config, T).parseArgs(t, ["-s","S"]).helpOnErrorCommandNames.length == 1);
+    }}
+
+    {
+        enum Config config = {
+            helpOnError: Config.HelpOnError.none,
+            stylingMode: Config.StylingMode.off,
+            helpPrinter: (cfg, style, cmds) => assert(false),
+            errorHandler: (msg) { },
+        };
+
+        T t;
+        assert(CLI!(config, T).parseArgs(t, []).isError("The following argument is required"));
+        assert(CLI!(config, T).parseArgs(t, ["-s","S","extra"]).isError("Unrecognized arguments"));
+
+        // `none` must not compute the help info at all
+        string[] unrecognizedArgs;
+        assert(.parseArgs!config(t, [], unrecognizedArgs).cmdHelpInfo.length == 0);
+    }
+}
+
+unittest
+{
+    import argparse.api.argument;
+    import argparse.api.command: Command;
+    import argparse.api.subcommand: SubCommand;
+
+    // Whatever is printed belongs to the command that was actually being parsed, not to the top level one
+    struct sub
+    {
+        @(NamedArgument.Required) string req;
+    }
+
+    @(Command("prog"))
+    struct T
+    {
+        SubCommand!sub cmd;
+    }
+
+    enum Config config = {
+        helpOnError: Config.HelpOnError.usage,
+        stylingMode: Config.StylingMode.off,
+        errorHandler: (msg) { },
+    };
+
+    T t;
+
+    // Error raised while parsing the subcommand
+    assert(CLI!(config, T).parseArgs(t, ["sub"]).helpOnErrorCommandNames == ["prog","sub"]);
+
+    // Unrecognized arguments are detected once parsing succeeded, so this only works because a successful
+    // result carries the help info as well
+    assert(CLI!(config, T).parseArgs(t, ["sub","--req","R","extra"]).helpOnErrorCommandNames == ["prog","sub"]);
+
+    // Top level error still reports the top level command
+    assert(CLI!(config, T).parseArgs(t, ["extra"]).helpOnErrorCommandNames == ["prog"]);
 }

--- a/source/argparse/config.d
+++ b/source/argparse/config.d
@@ -86,6 +86,15 @@ struct Config
     bool addHelpArgument = true;
 
     /**
+       What is printed to stderr in front of the error message when command line parsing failed.
+       Whatever is printed belongs to the command that was being parsed when the error happened, so an
+       error in a subcommand refers to that subcommand rather than to the top level command.
+       Defaults to printing nothing.
+     */
+    enum HelpOnError { none, usage, full }
+    HelpOnError helpOnError = HelpOnError.none;
+
+    /**
        Styling.
      */
     Style styling = Style.Default;

--- a/source/argparse/internal/commandstack.d
+++ b/source/argparse/internal/commandstack.d
@@ -1,9 +1,11 @@
 module argparse.internal.commandstack;
 
 import argparse.config;
+import argparse.helpinfo: CommandHelpInfo;
 import argparse.result;
 import argparse.internal.command;
 import argparse.internal.commandinfo: getTopLevelCommandInfo;
+import argparse.internal.helpargument: getProgramName;
 
 import std.range: back, popBack;
 
@@ -42,6 +44,19 @@ package struct CommandStack
         import std.range: join;
 
         return stack.map!((ref _) => _.suggestions(arg)).join.sort.uniq.array;
+    }
+
+    CommandHelpInfo[] helpInfo() const
+    {
+        import std.algorithm: map;
+        import std.array: array;
+
+        auto res = stack.map!((ref _) => _.helpInfo).array;
+
+        if(res[0].name.length == 0)
+            res[0].name = getProgramName(); // set command name to executable name
+
+        return res;
     }
 
     auto finalize(const Config config)

--- a/source/argparse/internal/parser.d
+++ b/source/argparse/internal/parser.d
@@ -12,6 +12,17 @@ package(argparse) Result parseArgs(Config config, COMMAND)(ref COMMAND receiver,
 {
     auto cmdStack = createCommandStack!config(receiver);
 
+    // This is the only place where the failing result and the command stack that produced it are both
+    // alive, so it is where the help information for the active command is attached to the result.
+    // It is a no-op when Config.helpOnError is `none`.
+    Result attachHelpInfo(Result res)
+    {
+        static if(config.helpOnError != Config.HelpOnError.none)
+            res.cmdHelpInfo = cmdStack.helpInfo();
+
+        return res;
+    }
+
     foreach(entry; Tokenizer(config, args, &cmdStack))
     {
         import std.sumtype : match;
@@ -22,10 +33,10 @@ package(argparse) Result parseArgs(Config config, COMMAND)(ref COMMAND receiver,
                 (ref Unknown u) { unrecognizedArgs ~= u.value; return Result.Success; }
             );
         if (!res)
-            return res;
+            return attachHelpInfo(res);
     }
 
-    return cmdStack.finalize(config);
+    return attachHelpInfo(cmdStack.finalize(config));
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/source/argparse/result.d
+++ b/source/argparse/result.d
@@ -1,5 +1,7 @@
 module argparse.result;
 
+import argparse.helpinfo: CommandHelpInfo;
+
 
 struct Result
 {
@@ -47,6 +49,12 @@ struct Result
     private string errorMsg;
 
     package string errorMessage() const { return errorMsg; }
+
+    // Help information for the stack of commands that was active when this result was produced.
+    // It is populated by the parser unless Config.helpOnError is `none`. Successful results
+    // carry it as well, so that errors that are detected after parsing has completed (unrecognized
+    // arguments) can still print the help screen of the command that was actually being parsed.
+    package CommandHelpInfo[] cmdHelpInfo;
 
     version(unittest)
     {


### PR DESCRIPTION
Closes #266 

`Config` has new setting:
```d
    enum HelpOnError { none, usage, full }
    HelpOnError helpOnError = HelpOnError.none;
```