### PR TITLE
Print default values in help screen

### DIFF
--- a/docs/code_snippets/help_default_value.d
+++ b/docs/code_snippets/help_default_value.d
@@ -1,0 +1,28 @@
+import argparse;
+import std.typecons: Nullable;
+
+struct T
+{
+    enum Mode { fast, slow }
+
+    @(NamedArgument.Description("path to config file"))
+    string config = "/etc/app.conf";
+
+    @(NamedArgument.Description("mode to use"))
+    Mode mode;
+
+    @(NamedArgument.Description("tags to filter by"))
+    string[] tags;
+
+    // default value is provided in runtime
+    @(NamedArgument.Description("number of threads")
+     .PrintDefaultValueInHelp(() => Nullable!string("number of CPUs")))
+    int threads;
+
+    // default value is not printed even though it's not empty
+    @(NamedArgument.Description("output file").PrintDefaultValueInHelp(false))
+    string output = "out.txt";
+}
+
+T t;
+CLI!T.parseArgs(t, ["-h"]);

--- a/docs/topics/Help-generation.md
+++ b/docs/topics/Help-generation.md
@@ -32,6 +32,41 @@ There are some customizations supported on argument level for both `PositionalAr
   value – the latter can be used to return a value that is not known at compile time.
 - `Hidden` – can be used to indicate that the argument shouldn’t be printed in help message.
 - `Placeholder` – provides custom text that is used to indicate the value of the argument in help message.
+- `PrintDefaultValueInHelp` – overrides whether the default value of the argument is printed in help message.
+
+## Default value of an argument
+
+The default value of an optional argument is printed next to its description if there is something meaningful to print:
+either the type of the argument is `enum` or the argument is initialized with a value that is different from the init
+value of its type. Required arguments never print their default value automatically since it is never used.
+
+The value is printed in the same format that is expected in command line, so it can be copy-pasted from help screen:
+values of an array are printed as a comma-separated list and values of an associative array are printed as a
+comma-separated list of `key=value` pairs.
+
+`PrintDefaultValueInHelp` modifier overrides this behavior: it takes either `bool` (`true` – always print the default
+value, `false` – never print it) or a function that returns `Nullable!string` (`null` – don’t print the default value,
+otherwise the returned string is printed as the default value) – the latter can be used to provide a value that is not
+known at compile time.
+
+<code-block src="code_snippets/help_default_value.d" lang="c++"/>
+
+This example prints the following:
+
+```
+Optional arguments:
+  --config CONFIG       path to config file (default: /etc/app.conf)
+  --mode {fast,slow}    mode to use (default: fast)
+  --tags TAGS ...       tags to filter by
+  --threads THREADS     number of threads (default: number of CPUs)
+  --output OUTPUT       output file
+  -h, --help            Show this help message and exit
+```
+
+> Note that if the default value of an argument can’t be converted to string at compile time (for example, if `toString`
+> of its type can’t be executed at compile time) then it is not printed. In this case `PrintDefaultValueInHelp(true)`
+> results in a compilation error – the function above should be used instead.
+{style="note"}
 
 ## Help text styling
 

--- a/docs/topics/Help-generation.md
+++ b/docs/topics/Help-generation.md
@@ -20,6 +20,9 @@
 `Usage`, `Description`, `ShortDescription` and `Epilog` modifiers take either `string` or `string function()`
 value – the latter can be used to return a value that is not known at compile time.
 
+A [default subcommand](Subcommands.md#default-subcommand) is marked with `(default)` next to its name in
+*Available commands* section on help screen of the parent command.
+
 ## Argument
 
 There are some customizations supported on argument level for both `PositionalArgument` and `NamedArgument` UDAs:

--- a/docs/topics/Subcommands.md
+++ b/docs/topics/Subcommands.md
@@ -56,6 +56,16 @@ To mark a subcommand as default, use `Default` template:
 
 <code-block src="code_snippets/subcommands_default.d" lang="c++"/>
 
+Default subcommand is marked with `(default)` next to its name in *Available commands* section on help screen of the
+parent command:
+
+```
+Available commands:
+  sum (default)
+  min
+  max
+```
+
 ## Enumerating subcommands in CLI mixin
 
 One of the possible ways to use subcommands with `argparse` is to list all subcommands in `CLI` mixin. Although this might

--- a/docs/topics/reference/...HelpInfo.md
+++ b/docs/topics/reference/...HelpInfo.md
@@ -31,6 +31,7 @@ There are few structs that describe help information for argument parsing entiti
 
 - `const string[] names` - subcommand names.
 - `string description` - subcommand description.
+- `bool isDefault` - flag denoting that a subcommand is the default one.
 
 ## CommandHelpInfo
 

--- a/docs/topics/reference/...HelpInfo.md
+++ b/docs/topics/reference/...HelpInfo.md
@@ -10,6 +10,7 @@ There are few structs that describe help information for argument parsing entiti
 - `const string[] longNames` - long names of an argument NOT prefixed with `Config.longNamePrefix`.
 - `string description` - description of an argument.
 - `string placeholder` - value placeholder (eg. `VALUE` for `--foo VALUE` argument).
+- `Nullable!string defaultValue` - default value of an argument that should be printed on help screen; `null` if it should not be printed.
 - `bool multipleOccurrence` - flag denoting that an argument can appear multiple times in command line.
 - `bool optionalValue` - flag denoting that the value is optional for argument.
 - `bool optionalArgument` - flag denoting that an argument itself is optional.

--- a/docs/topics/reference/HelpPrinter.md
+++ b/docs/topics/reference/HelpPrinter.md
@@ -99,6 +99,28 @@ string formatArgumentValue(in ArgumentHelpInfo helpInfo)
 
 String with formatted argument value.
 
+### formatArgumentDescription
+
+`formatArgumentDescription` returns the description of an argument that is printed next to its name, including the
+default value of the argument if it should be printed. For example, it returns `path to config (default: /etc/app.conf)`
+for an argument that is described as `path to config` and has `/etc/app.conf` default value.
+
+**Signature**
+
+```c++
+string formatArgumentDescription(in ArgumentHelpInfo helpInfo)
+```
+
+**Parameters**
+
+- `helpInfo`
+
+  Help info about argument.
+
+**Return value**
+
+String with formatted argument description.
+
 ### createHelpScreen
 
 This function creates [`HelpScreen`](HelpScreen.md) based on list of [commands](...HelpInfo.md#commandhelpinfo).

--- a/docs/topics/reference/PositionalNamedArgument.md
+++ b/docs/topics/reference/PositionalNamedArgument.md
@@ -122,6 +122,45 @@ struct my_command
 }
 ```
 
+### PrintDefaultValueInHelp
+
+`PrintDefaultValueInHelp` overrides whether the default value of the argument is printed in help message. See
+[Default value of an argument](Help-generation.md#default-value-of-an-argument) for details about the default behavior.
+
+**Signature**
+
+```C++
+PrintDefaultValueInHelp(auto ref ... argument, bool print = true)
+PrintDefaultValueInHelp(auto ref ... argument, Nullable!string function() value)
+```
+
+**Parameters**
+
+- `print`
+
+  If `true` then the default value of the argument is printed in help message, otherwise it is not printed.
+  Note that compilation fails if the default value can't be converted to string at compile time – `value` parameter
+  below should be used in this case.
+
+- `value`
+
+  Function that returns the default value that is printed in help message. If it returns `null` then nothing is
+  printed. It can be used to provide a value that is not known at compile time. Note that `Nullable` comes from
+  `std.typecons` so it has to be imported.
+
+**Usage example**
+
+```C++
+struct my_command
+{
+  @(NamedArgument.PrintDefaultValueInHelp(false))
+  int a = 10;
+
+  @(NamedArgument.PrintDefaultValueInHelp(() => Nullable!string("number of CPUs")))
+  int threads;
+}
+```
+
 ### Required
 
 Mark an argument as required so if it is not provided in command line, `argparse` will error out.

--- a/source/argparse/api/argument.d
+++ b/source/argparse/api/argument.d
@@ -12,6 +12,8 @@ import argparse.internal.parsefunc;
 import argparse.internal.validationfunc;
 import argparse.internal.utils: formatAllowedValues;
 
+import std.typecons: Nullable;
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Public API for argument UDA
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -61,6 +63,18 @@ auto ref Hidden(T)(auto ref ArgumentUDA!T uda, bool hide = true)
 auto ref Placeholder(T)(auto ref ArgumentUDA!T uda, string value)
 {
     uda.info.placeholder = value;
+    return uda;
+}
+
+auto ref PrintDefaultValueInHelp(T)(auto ref ArgumentUDA!T uda, bool print = true)
+{
+    uda.info.printDefaultValue = print;
+    return uda;
+}
+
+auto ref PrintDefaultValueInHelp(T)(auto ref ArgumentUDA!T uda, Nullable!string function() value)
+{
+    uda.info.defaultValue = value;
     return uda;
 }
 
@@ -128,6 +142,18 @@ unittest
 
     arg = arg.Description(() => "qwer").Placeholder("text");
     assert(arg.info.description.get == "qwer");
+
+    assert(arg.info.printDefaultValue.isNull);
+    assert(arg.info.defaultValue is null);
+
+    arg = arg.PrintDefaultValueInHelp;
+    assert(arg.info.printDefaultValue == true);
+
+    arg = arg.PrintDefaultValueInHelp(false);
+    assert(arg.info.printDefaultValue == false);
+
+    arg = arg.PrintDefaultValueInHelp(() => Nullable!string("some value"));
+    assert(arg.info.defaultValue() == "some value");
 
     arg = arg.Hidden.Required.NumberOfValues(10);
     assert(arg.info.hidden);

--- a/source/argparse/helpinfo.d
+++ b/source/argparse/helpinfo.d
@@ -32,6 +32,8 @@ public struct SubCommandHelpInfo
 {
     const string[] names;
     string description;
+
+    bool isDefault;
 }
 
 public struct CommandHelpInfo

--- a/source/argparse/helpinfo.d
+++ b/source/argparse/helpinfo.d
@@ -1,6 +1,7 @@
 module argparse.helpinfo;
 
 import std.algorithm.iteration;
+import std.typecons: Nullable;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -12,6 +13,9 @@ public struct ArgumentHelpInfo
 
     string description;
     string placeholder;
+
+    // Default value of an argument that should be printed on help screen; null if it should not be printed
+    Nullable!string defaultValue;
 
     bool multipleOccurrence;
     bool optionalValue;

--- a/source/argparse/helpprinter.d
+++ b/source/argparse/helpprinter.d
@@ -8,6 +8,7 @@ import std.algorithm;
 import std.conv: text;
 import std.range;
 import std.string;
+import std.typecons: Nullable, nullable;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -176,6 +177,20 @@ public class HelpPrinter
         }
     }
 
+    string formatArgumentDescription(in ArgumentHelpInfo helpInfo)
+    {
+        if(helpInfo.defaultValue.isNull)
+            return helpInfo.description.idup;   // copy is needed to not return a slice of `scope` parameter
+
+        auto value = helpInfo.positional ?
+                     style.positionalArgumentValue(helpInfo.defaultValue.get) :
+                     style.namedArgumentValue(helpInfo.defaultValue.get);
+
+        auto mark = "(default: " ~ value ~ ")";
+
+        return helpInfo.description.length > 0 ? helpInfo.description ~ " " ~ mark : mark;
+    }
+
     string formatCommandUsage(string[] commandName, in CommandHelpInfo helpInfo)
     {
         string usage;
@@ -248,7 +263,7 @@ public class HelpPrinter
                 groups[index].parameters ~= group.argIndex
                     .map!(_ => cmd.arguments[_])
                     .filter!(showArg)
-                    .map!(_ => HelpScreen.Parameter(formatArgumentUsage(_, false), _.description))
+                    .map!(_ => HelpScreen.Parameter(formatArgumentUsage(_, false), formatArgumentDescription(_)))
                     .array;
             }
         }
@@ -427,6 +442,26 @@ unittest
 
     assert(test(true) == "-f");
     assert(test(false) == "-f, --[no-]foo");
+}
+
+unittest
+{
+    scope hp = new HelpPrinter(Config.init, Style.None);
+
+    auto test(string description, Nullable!string defaultValue, bool positional = false)
+    {
+        return hp.formatArgumentDescription(ArgumentHelpInfo(
+                description: description,
+                defaultValue: defaultValue,
+                positional: positional));
+    }
+
+    assert(test("desc", Nullable!string.init) == "desc");
+    assert(test("", Nullable!string.init) == "");
+    assert(test("desc", nullable("abc")) == "desc (default: abc)");
+    assert(test("", nullable("abc")) == "(default: abc)");
+    assert(test("desc", nullable("")) == "desc (default: )");
+    assert(test("desc", nullable("abc"), true) == "desc (default: abc)");
 }
 
 unittest

--- a/source/argparse/helpprinter.d
+++ b/source/argparse/helpprinter.d
@@ -24,6 +24,19 @@ unittest
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+private string defaultMark(bool isDefault)
+{
+    return isDefault ? " (default)" : "";
+}
+
+unittest
+{
+    assert(defaultMark(false) == "");
+    assert(defaultMark(true) == " (default)");
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 public struct HelpScreen
 {
     struct Parameter
@@ -191,7 +204,8 @@ public class HelpPrinter
             title: style.argumentGroupTitle("Available commands"),
             parameters: cmd.subCommands
                 .map!((ref _) =>
-                    HelpScreen.Parameter(_.names.map!(_ => style.subcommandName(_)).join(","), _.description))
+                    HelpScreen.Parameter(_.names.map!(_ => style.subcommandName(_)).join(",") ~ defaultMark(_.isDefault),
+                                         _.description))
                 .array
         );
     }
@@ -421,6 +435,26 @@ unittest
     auto res = hp.formatCommandUsage(["a","b"], CommandHelpInfo(usage: "%(PROG) my usage"));
 
     assert(res == "Usage: a b my usage");
+}
+
+unittest
+{
+    scope hp = new HelpPrinter(Config.init, Style.None);
+
+    CommandHelpInfo cmd = {
+        subCommands: [
+            SubCommandHelpInfo(["cmd1"], "desc1", true),
+            SubCommandHelpInfo(["cmd2","c2"], "desc2"),
+        ]
+    };
+
+    auto res = hp.createSubCommandGroup(cmd);
+
+    assert(res.title == "Available commands");
+    assert(res.parameters == [
+        HelpScreen.Parameter("cmd1 (default)", "desc1"),
+        HelpScreen.Parameter("cmd2,c2", "desc2"),
+    ]);
 }
 
 unittest

--- a/source/argparse/internal/arguments.d
+++ b/source/argparse/internal/arguments.d
@@ -37,6 +37,10 @@ package(argparse) struct ArgumentInfo
     bool isBooleanFlag = false;
     bool positional;
 
+    // `printDefaultValue` is consumed by `getMemberArgumentUDA` that translates it into `defaultValue`
+    Nullable!bool printDefaultValue;
+    Nullable!string function() defaultValue;
+
     auto helpInfo() const
     {
         return ArgumentHelpInfo(
@@ -44,6 +48,7 @@ package(argparse) struct ArgumentInfo
             longNames: longNames,
             description: description.get,
             placeholder: placeholder,
+            defaultValue: defaultValue is null ? Nullable!string.init : defaultValue(),
             multipleOccurrence: maxValuesCount.get > 1,
             optionalValue: minValuesCount.get == 0,
             optionalArgument: !required,
@@ -120,6 +125,23 @@ unittest
     assert(info(1,2,1));
     assert(info(1,2,2));
     assert(info(1,2,3).isError("expected at most 2 values"));
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+unittest
+{
+    ArgumentInfo info;
+    info.minValuesCount = 0;
+    info.maxValuesCount = 1;
+
+    assert(info.helpInfo.defaultValue.isNull);
+
+    info.defaultValue = () => Nullable!string("abc");
+    assert(info.helpInfo.defaultValue == "abc");
+
+    info.defaultValue = () => Nullable!string.init;
+    assert(info.helpInfo.defaultValue.isNull);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/source/argparse/internal/argumentuda.d
+++ b/source/argparse/internal/argumentuda.d
@@ -6,6 +6,8 @@ import argparse.result;
 import argparse.internal.arguments: ArgumentInfo;
 import argparse.internal.valueparser: parseParameter;
 
+import std.typecons: Nullable;
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 package(argparse) auto createArgumentUDA(ValueParser)(ArgumentInfo info, ValueParser valueParser)
@@ -45,6 +47,8 @@ package(argparse) struct ArgumentUDA(ValueParser)
         if(!newInfo.positional) newInfo.positional = uda.info.positional;
         if(newInfo.minValuesCount.isNull()) newInfo.minValuesCount = uda.info.minValuesCount;
         if(newInfo.maxValuesCount.isNull()) newInfo.maxValuesCount = uda.info.maxValuesCount;
+        if(newInfo.printDefaultValue.isNull()) newInfo.printDefaultValue = uda.info.printDefaultValue;
+        if(newInfo.defaultValue is null) newInfo.defaultValue = uda.info.defaultValue;
 
         auto newValueParser = valueParser.addDefaults(uda.valueParser);
 
@@ -84,6 +88,8 @@ unittest
     arg1.info.positional = true;
     arg1.info.minValuesCount = 2;
     arg1.info.maxValuesCount = 3;
+    arg1.info.printDefaultValue = true;
+    arg1.info.defaultValue = () => Nullable!string("def1");
 
     ArgumentUDA!(S!"foo2") arg2;
     arg2.info.shortNames = ["a2","b2"];
@@ -94,6 +100,8 @@ unittest
     arg1.info.positional = true;
     arg2.info.minValuesCount = 20;
     arg2.info.maxValuesCount = 30;
+    arg2.info.printDefaultValue = false;
+    arg2.info.defaultValue = () => Nullable!string("def2");
 
     {
         // values shouldn't be changed
@@ -105,6 +113,8 @@ unittest
         assert(res.info.position.get == 1);
         assert(res.info.minValuesCount == 2);
         assert(res.info.maxValuesCount == 3);
+        assert(res.info.printDefaultValue == true);
+        assert(res.info.defaultValue() == "def1");
         assert(res.valueParser.str == "foo1");
     }
 
@@ -117,6 +127,8 @@ unittest
         assert(res.info.position.get == 1);
         assert(res.info.minValuesCount == 2);
         assert(res.info.maxValuesCount == 3);
+        assert(res.info.printDefaultValue == true);
+        assert(res.info.defaultValue() == "def1");
         assert(res.valueParser.str == "foo1");
     }
 }

--- a/source/argparse/internal/argumentudahelpers.d
+++ b/source/argparse/internal/argumentudahelpers.d
@@ -5,7 +5,10 @@ import argparse.config;
 import argparse.internal.argumentuda: ArgumentUDA;
 import argparse.internal.arguments: finalize;
 import argparse.internal.booleanhelpers;
+import argparse.internal.defaultvaluehelpers;
 import argparse.param;
+
+import std.typecons: Nullable;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -144,6 +147,22 @@ package auto getMemberArgumentUDA(TYPE, string symbol)(const Config config)
     static if(initUDA.info.minValuesCount.isNull) result.info.minValuesCount = defaultValuesCount!MemberType.min;
     static if(initUDA.info.maxValuesCount.isNull) result.info.maxValuesCount = defaultValuesCount!MemberType.max;
 
+    // Default value is printed if it's explicitly requested or, for an optional argument, if there is something
+    // meaningful to print: enum value or an initializer that differs from the init value of the member type.
+    // Note that explicit request of a value that can't be formatted in compile time is a compilation error
+    enum printDefaultValue = initUDA.info.printDefaultValue.get(
+        !initUDA.info.required && (is(MemberType == enum) || hasDefaultValue!(TYPE, symbol)));
+
+    static if(printDefaultValue)
+    {
+        static assert(__traits(compiles, defaultValueText!(TYPE, symbol)),
+            "Can't get default value of "~TYPE.stringof~"."~symbol~
+            ": use PrintDefaultValueInHelp with a function that returns Nullable!string");
+
+        if(result.info.defaultValue is null)    // it's not set through PrintDefaultValueInHelp
+            result.info.defaultValue = () => Nullable!string(defaultValueText!(TYPE, symbol));
+    }
+
     return result;
 }
 
@@ -222,4 +241,46 @@ unittest
     assert(res.maxValuesCount == 2);
 
     assert(!__traits(compiles, getInfo!"mult1"));
+}
+
+unittest
+{
+    import argparse.api.argument: NamedArgument, Required, PrintDefaultValueInHelp;
+
+    enum E { a, b }
+
+    struct Args
+    {
+        string s = "abc";
+        string sInit;
+        E e;
+        @(NamedArgument.Required) E eRequired;
+        @(NamedArgument.PrintDefaultValueInHelp(false)) E eDisabled;
+        @(NamedArgument.PrintDefaultValueInHelp) string forced;
+        @(NamedArgument.PrintDefaultValueInHelp(() => Nullable!string("custom"))) int func;
+        @(NamedArgument.PrintDefaultValueInHelp(() => Nullable!string.init)) string suppressed = "abc";
+        int[] arr = [1,2];
+        string[][] cantFormat = [["a"],["b"]];
+        @(NamedArgument.PrintDefaultValueInHelp) string[][] cantFormatButRequested;
+    }
+
+    auto defaultValue(string symbol)()
+    {
+        auto get = getMemberArgumentUDA!(Args, symbol)(Config.init).info.defaultValue;
+        return get is null ? Nullable!string.init : get();
+    }
+
+    assert(defaultValue!"s" == "abc");
+    assert(defaultValue!"sInit".isNull);
+    assert(defaultValue!"e" == "a");
+    assert(defaultValue!"eRequired".isNull);
+    assert(defaultValue!"eDisabled".isNull);
+    assert(defaultValue!"forced" == "");
+    assert(defaultValue!"func" == "custom");
+    assert(defaultValue!"suppressed".isNull);
+    assert(defaultValue!"arr" == "1,2");
+
+    // there is no way to print the default value of these
+    assert(defaultValue!"cantFormat".isNull);
+    assert(!__traits(compiles, defaultValue!"cantFormatButRequested"));
 }

--- a/source/argparse/internal/command.d
+++ b/source/argparse/internal/command.d
@@ -256,7 +256,8 @@ package struct Command
             subCommands: subCommands.info
                 .filter!((ref _) => _.displayNames.length > 0 && _.displayNames[0].length > 0)
                 .map!((ref _) => SubCommandHelpInfo(_.displayNames,
-                                                    _.shortDescription.isSet ? _.shortDescription.get : _.description.get))
+                                                    _.shortDescription.isSet ? _.shortDescription.get : _.description.get,
+                                                    _.isDefaultSubCommand))
                 .array
         );
     }

--- a/source/argparse/internal/defaultvaluehelpers.d
+++ b/source/argparse/internal/defaultvaluehelpers.d
@@ -1,0 +1,202 @@
+module argparse.internal.defaultvaluehelpers;
+
+import argparse.internal.enumhelpers: getEnumValueName;
+
+import std.traits;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// A value that is provided as a single item in command line: it's neither an array (string is an exception
+// since it's provided as is) nor an associative array
+private enum isFlatValue(T) = (!isArray!T || isSomeString!T) && !isAssociativeArray!T;
+
+// Default value can be printed only if it's possible to provide it in one command line token:
+// a flat value itself, an array of flat values or an associative array with flat keys and values
+private enum isSupportedDefaultValue(T) =
+    isFlatValue!T ||
+    (isArray!T && isFlatValue!(ForeachType!T)) ||
+    (isAssociativeArray!T && isFlatValue!(KeyType!T) && isFlatValue!(ValueType!T));
+
+unittest
+{
+    enum E { a, b }
+
+    assert(isSupportedDefaultValue!int);
+    assert(isSupportedDefaultValue!bool);
+    assert(isSupportedDefaultValue!string);
+    assert(isSupportedDefaultValue!E);
+    assert(isSupportedDefaultValue!(int[]));
+    assert(isSupportedDefaultValue!(int[3]));
+    assert(isSupportedDefaultValue!(string[]));
+    assert(isSupportedDefaultValue!(int[string]));
+
+    // there is no way to provide these in one command line token
+    assert(!isSupportedDefaultValue!(int[][]));
+    assert(!isSupportedDefaultValue!(int[][string]));
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Formats a value the same way as it should be provided in command line so it can be copy-pasted from help screen
+private string formatDefaultValue(T)(auto ref T value)
+if(isSupportedDefaultValue!T)
+{
+    import std.algorithm: map;
+    import std.array: join;
+    import std.conv: text;
+
+    static if(is(T == enum))
+        return getEnumValueName(value);
+    else static if(isSomeString!T)
+        return text(value);
+    else static if(isAssociativeArray!T)
+    {
+        string[] values;
+
+        foreach(k, v; value)
+            values ~= formatDefaultValue(k) ~ "=" ~ formatDefaultValue(v);
+
+        return values.join(",");
+    }
+    else static if(isArray!T)
+        return value[].map!((ref _) => formatDefaultValue(_)).join(",");
+    else
+        return text(value);
+}
+
+unittest
+{
+    enum E { a, b }
+
+    assert(formatDefaultValue(5) == "5");
+    assert(formatDefaultValue(true) == "true");
+    assert(formatDefaultValue("abc") == "abc");
+    assert(formatDefaultValue("") == "");
+    assert(formatDefaultValue(E.b) == "b");
+    assert(formatDefaultValue([1,2,3]) == "1,2,3");
+    assert(formatDefaultValue(cast(int[3]) [1,2,3]) == "1,2,3");
+    assert(formatDefaultValue(["a","b"]) == "a,b");
+    assert(formatDefaultValue([E.a,E.b]) == "a,b");
+    assert(formatDefaultValue(["a": 1]) == "a=1");
+    assert(formatDefaultValue(cast(int[]) []) == "");
+}
+
+unittest
+{
+    import argparse.internal.enumhelpers: EnumValue;
+
+    enum E { @EnumValue(["x","y"]) a, b }
+
+    assert(formatDefaultValue(E.a) == "x");
+    assert(formatDefaultValue([E.a,E.b]) == "x,b");
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Member functions (i.e. callbacks) have no default value. This check is also necessary to prevent
+// `TYPE.init.symbol` from calling a member function through optional parentheses
+private enum isDataMember(TYPE, string symbol) =
+    !is(typeof(__traits(getMember, TYPE, symbol)) == function) &&
+    !is(typeof(__traits(getMember, TYPE, symbol)) == delegate);
+
+// Value that a member is initialized with, i.e. what a command gets if an argument is not provided in command line
+private template initValueOf(TYPE, string symbol)
+{
+    static if(is(TYPE == class))
+        enum initValueOf = __traits(getMember, new TYPE, symbol);   // TYPE.init is null for classes
+    else
+        enum initValueOf = __traits(getMember, TYPE.init, symbol);
+}
+
+// Text that is printed on help screen as the default value of an argument. It doesn't compile if the value can't be
+// formatted in compile time, i.e. if its type is not supported (see `isSupportedDefaultValue`) or, for a struct or a
+// class, if its `toString`/constructor can't be executed by CTFE
+package(argparse) template defaultValueText(TYPE, string symbol)
+if(isDataMember!(TYPE, symbol))
+{
+    enum defaultValueText = formatDefaultValue(initValueOf!(TYPE, symbol));
+}
+
+// True if a member has a default value that can be printed on help screen, i.e. it is initialized with something
+// different from the init value of its type and that value can be formatted. Note that there is no way to distinguish
+// `int i;` from `int i = 0;` so the latter is not considered as having a default value
+package(argparse) template hasDefaultValue(TYPE, string symbol)
+{
+    private alias MemberType = typeof(__traits(getMember, TYPE, symbol));
+
+    static if(isDataMember!(TYPE, symbol) &&
+              __traits(compiles, { enum _ = initValueOf!(TYPE, symbol) != MemberType.init; }) &&
+              __traits(compiles, defaultValueText!(TYPE, symbol)))
+        enum hasDefaultValue = initValueOf!(TYPE, symbol) != MemberType.init;
+    else
+        enum hasDefaultValue = false;
+}
+
+unittest
+{
+    enum E { a, b }
+
+    struct NoCompare { int i; @disable bool opEquals(const NoCompare) const; }
+    struct NoCTFE   { int i = 1; string toString() const { assert(!__ctfe); return "rt"; } }
+
+    struct T
+    {
+        string s = "abc";
+        string sInit;
+        E e;
+        int i = 5;
+        int[] a = [1,2];
+        int[][] a2 = [[1,2]];
+        NoCompare nc;
+        NoCTFE nf = NoCTFE(2);
+        void func() {}
+    }
+
+    assert( hasDefaultValue!(T, "s"));
+    assert(!hasDefaultValue!(T, "sInit"));
+    assert(!hasDefaultValue!(T, "e"));
+    assert( hasDefaultValue!(T, "i"));
+    assert( hasDefaultValue!(T, "a"));
+    assert(!hasDefaultValue!(T, "nc"));
+    assert(!hasDefaultValue!(T, "a2"));     // can't be formatted
+    assert(!hasDefaultValue!(T, "nf"));     // can't be formatted
+    assert(!hasDefaultValue!(T, "func"));
+
+    assert(!__traits(compiles, defaultValueText!(T, "a2")));
+    assert(!__traits(compiles, defaultValueText!(T, "nf")));
+    assert(!__traits(compiles, defaultValueText!(T, "func")));
+
+    assert(defaultValueText!(T, "s") == "abc");
+    assert(defaultValueText!(T, "sInit") == "");
+    assert(defaultValueText!(T, "e") == "a");
+    assert(defaultValueText!(T, "i") == "5");
+    assert(defaultValueText!(T, "a") == "1,2");
+
+    assert(NoCTFE(1).toString == "rt");     // it's CTFE that is not supported by this type
+}
+
+unittest
+{
+    static class C
+    {
+        string s = "abc";
+        int i;
+    }
+
+    assert( hasDefaultValue!(C, "s"));
+    assert(!hasDefaultValue!(C, "i"));
+    assert(defaultValueText!(C, "s") == "abc");
+
+    static class NoCTFE
+    {
+        string s = "abc";
+        this() { assert(!__ctfe); }
+    }
+
+    assert(!hasDefaultValue!(NoCTFE, "s"));
+    assert(!__traits(compiles, defaultValueText!(NoCTFE, "s")));
+
+    assert((new NoCTFE).s == "abc");        // it's CTFE that is not supported by this type
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/source/argparse/internal/enumhelpers.d
+++ b/source/argparse/internal/enumhelpers.d
@@ -40,6 +40,27 @@ package E getEnumValue(E)(string value)
     return values[value];
 }
 
+// Returns the name that is used in command line for a specific enum value
+package string getEnumValueName(E)(E value)
+{
+    import std.traits: EnumMembers, getUDAs;
+
+    static foreach(mem; EnumMembers!E)
+    {{
+        enum valueUDAs = getUDAs!(mem, EnumValue);
+
+        static if(valueUDAs.length > 0)
+            enum name = valueUDAs[0].values[0];
+        else
+            enum name = mem.stringof;
+
+        if(value == mem)
+            return name;
+    }}
+
+    return null;
+}
+
 
 unittest
 {
@@ -49,6 +70,10 @@ unittest
     assert(getEnumValue!E("abc") == E.abc);
     assert(getEnumValue!E("def") == E.def);
     assert(getEnumValue!E("ghi") == E.ghi);
+    assert(getEnumValueName(E.abc) == "abc");
+    assert(getEnumValueName(E.def) == "def");
+    assert(getEnumValueName(E.ghi) == "ghi");
+    assert(getEnumValueName(cast(E) 100) is null);
 }
 
 unittest
@@ -66,6 +91,9 @@ unittest
     assert(getEnumValue!E("c") == E.abc);
     assert(getEnumValue!E("def") == E.def);
     assert(getEnumValue!E("ghi") == E.ghi);
+    assert(getEnumValueName(E.abc) == "a");
+    assert(getEnumValueName(E.def) == "def");
+    assert(getEnumValueName(E.ghi) == "ghi");
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/source/argparse/package.d
+++ b/source/argparse/package.d
@@ -1229,6 +1229,63 @@ unittest
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// https://github.com/andrey-zherikov/argparse/issues/148
+unittest
+{
+    import std.typecons: Nullable;
+
+    @(Command("MYPROG"))
+    struct T
+    {
+        enum Mode { WALK, RUN }
+
+        @(NamedArgument.Description("desc for a"))      string a = "abc";
+        @NamedArgument                                  string b;
+        @NamedArgument                                  Mode mode;
+        @(NamedArgument.Required)                       Mode req;
+        @(NamedArgument.PrintDefaultValueInHelp(false)) Mode quiet;
+        @(NamedArgument.PrintDefaultValueInHelp)        string forced;
+        @(NamedArgument.PrintDefaultValueInHelp(() => Nullable!string("number of CPUs"))) int j;
+        @(NamedArgument.PrintDefaultValueInHelp(() => Nullable!string.init))              string k = "abc";
+        @NamedArgument                                  string[] arr = ["x","y"];
+        @NamedArgument                                  int[string] aa = ["a":1];
+        @(PositionalArgument(0).Optional)               string pos = "xyz";
+    }
+
+    import std.array: appender;
+
+    enum Config config = {
+        styling: Style.None,
+        helpPrinter: (config, style, stack) {
+            scope hp = new HelpPrinter(config, style);
+
+            auto output = appender!string;
+            hp.printHelp(_ => output.put(_), stack);
+
+            assert(output[]  == "Usage: MYPROG [-a A] [-b B] [--mode {WALK,RUN}] --req {WALK,RUN} [--quiet {WALK,RUN}]"~
+            " [--forced FORCED] [-j J] [-k K] [--arr ARR ...] [--aa AA ...] [-h] [pos]\n\n"~
+            "Required arguments:\n"~
+            "  --req {WALK,RUN}\n\n"~
+            "Optional arguments:\n"~
+            "  -a A                  desc for a (default: abc)\n"~   // initialized with non-init value
+            "  -b B\n"~                                              // no initializer
+            "  --mode {WALK,RUN}     (default: WALK)\n"~             // enum
+            "  --quiet {WALK,RUN}\n"~                                // enum but explicitly disabled
+            "  --forced FORCED       (default: )\n"~                 // no initializer but explicitly enabled
+            "  -j J                  (default: number of CPUs)\n"~   // provided by a function
+            "  -k K\n"~                                              // suppressed by a function
+            "  --arr ARR ...         (default: x,y)\n"~
+            "  --aa AA ...           (default: a=1)\n"~
+            "  [pos]                 (default: xyz)\n"~
+            "  -h, --help            Show this help message and exit\n\n");
+        }
+    };
+
+    T t;
+    assert(CLI!(config, T).parseArgs(t, ["-h"]).isHelpWanted);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // https://github.com/andrey-zherikov/argparse/issues/231
 unittest {
     import std.process : environment;

--- a/source/argparse/package.d
+++ b/source/argparse/package.d
@@ -1157,6 +1157,48 @@ unittest
     @(Command("MYPROG"))
     struct T
     {
+        struct cmd1
+        {
+        }
+        @(Command.ShortDescription("Perform cmd 2"))
+        struct cmd2
+        {
+        }
+
+        string c;
+
+        SubCommand!(Default!cmd1, cmd2) cmd;
+    }
+
+    import std.array: appender;
+
+    enum Config config = {
+        styling: Style.None,
+        helpPrinter: (config, style, stack) {
+            scope hp = new HelpPrinter(config, style);
+
+            auto output = appender!string;
+            hp.printHelp(_ => output.put(_), stack);
+
+            assert(output[]  == "Usage: MYPROG [-c C] [-h] <command> [<args>]\n\n"~
+            "Available commands:\n"~
+            "  cmd1 (default)\n"~
+            "  cmd2              Perform cmd 2\n\n"~
+            "Optional arguments:\n"~
+            "  -c C\n"~
+            "  -h, --help        Show this help message and exit\n\n");
+        }
+    };
+
+    T t;
+    assert(CLI!(config, T).parseArgs(t, ["-h"]).isHelpWanted);
+}
+
+unittest
+{
+    @(Command("MYPROG"))
+    struct T
+    {
         @NamedArgument("f","foo")
         bool foo;
 


### PR DESCRIPTION
Closes #148 
```d
import argparse;
  import std.typecons: Nullable;

  @(Command("myprog"))
  struct T
  {
      enum Mode { fast, slow }

      @(PositionalArgument(0).Optional.Description("input file"))
      string input = "-";

      @(NamedArgument.Description("path to config file"))
      string config = "/etc/app.conf";

      @(NamedArgument.Description("mode to use"))
      Mode mode;

      @(NamedArgument.Description("tags to filter by"))
      string[] tags = ["foo","bar"];

      @(NamedArgument.Description("dimensions"))
      int[string] size = ["width":80, "height":25];

      @(NamedArgument.Description("verbosity level"))
      int verbosity;

      @(NamedArgument.Description("output format").Required)
      Mode format;

      // default value is known in runtime only
      @(NamedArgument.Description("number of threads")
       .PrintDefaultValueInHelp(() => Nullable!string("number of CPUs")))
      int threads;

      // default value is not printed even though it's not empty
      @(NamedArgument.Description("output file").PrintDefaultValueInHelp(false))
      string output = "out.txt";
  }

  mixin CLI!T.main!((args) => 0);
```

This code emits the following output for `myprog -h`:
```
Usage: myprog [--config CONFIG] [--mode {fast,slow}] [--tags TAGS ...] [--size SIZE ...] [--verbosity VERBOSITY] --format {fast,slow}
  [--threads THREADS] [--output OUTPUT] [-h] [input]

  Required arguments:
    --format {fast,slow}    output format

  Optional arguments:
    [input]                 input file (default: -)
    --config CONFIG         path to config file (default: /etc/app.conf)
    --mode {fast,slow}      mode to use (default: fast)
    --tags TAGS ...         tags to filter by (default: foo,bar)
    --size SIZE ...         dimensions (default: width=80,height=25)
    --verbosity VERBOSITY   verbosity level
    --threads THREADS       number of threads (default: number of CPUs)
    --output OUTPUT         output file
    -h, --help              Show this help message and exit
```